### PR TITLE
Dev 35 add a statues enum for the property on evdox ai models to streamline and modularize the code and add a missing column

### DIFF
--- a/models_src/dto/repo.py
+++ b/models_src/dto/repo.py
@@ -43,7 +43,7 @@ class RepoResponseDTO:
     repo_system_reference: Optional[str] = None
     repo_author_name: Optional[str] = None
     repo_author_email: Optional[str] = None
-
+    total_embeddings: Optional[int] = None
 
 @dataclass
 class RepoRequestDTO:

--- a/models_src/models/repo.py
+++ b/models_src/models/repo.py
@@ -1,6 +1,16 @@
+from enum import StrEnum
+
 from tortoise.models import Model
 from tortoise import fields
 import uuid
+
+
+class StatusTypes(StrEnum):
+    PENDING = "pending"
+    ANALYSIS_PENDING = "analysis pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    FAILED = "failed"
 
 
 class Repo(Model):
@@ -79,7 +89,7 @@ class Repo(Model):
         null=True, description="Error message if processing failed"
     )
     last_commit = fields.CharField(max_length=255, default="")
-    status = fields.CharField(max_length=255, default="pending")
+    status = fields.CharField(max_length=255, default=StatusTypes.PENDING)
 
     repo_alias_name = fields.CharField(
         max_length=100,

--- a/test/parity/models_src/models_dto_field_parity.py
+++ b/test/parity/models_src/models_dto_field_parity.py
@@ -1,0 +1,79 @@
+import dataclasses
+from dataclasses import fields, is_dataclass
+from typing import List, Optional, Set, Type
+
+from tortoise import Model
+
+from models_src.dto.api_key import APIKeyResponseDTO
+from models_src.dto.code_chunks import CodeChunksResponseDTO
+from models_src.dto.git_label import GitLabelResponseDTO
+from models_src.dto.queue_job_claim_registry import QueueProcessingRegistryResponseDTO
+from models_src.dto.repo import RepoResponseDTO
+from models_src.dto.user import UserResponseDTO
+from models_src.models.api_key import APIKEY
+from models_src.models.code_chunks import CodeChunks
+from models_src.models.git_label import GitLabel
+from models_src.models.queue_job_claim_registry import QueueProcessingRegistry
+from models_src.models.repo import Repo
+from models_src.models.user import User
+
+def symmetric_field_diff(
+    dataclass_type: Type[dataclasses],
+    tortoise_model: Type[Model],
+    exclude: Optional[set[str]] = None,
+) -> List[str]:
+    """
+    Return a sorted list of field names that exist in exactly one of:
+      1) the given dataclass (by dataclass field names), or
+      2) the given Tortoise ORM model (_meta.fields_map keys).
+
+    Args:
+        dataclass_type: The dataclass *type* to inspect.
+        tortoise_model: The Tortoise ORM model *class* to inspect.
+        exclude: Optional iterable of field names to remove from the final diff.
+
+    Example:
+        diff = symmetric_field_diff(UserDTO, UserModel, exclude={"created_at", "updated_at"})
+    """
+    if not is_dataclass(dataclass_type):
+        raise TypeError("dataclass_type must be a dataclass type (class decorated with @dataclass).")
+
+    dto_fields: Set[str] = {f.name for f in fields(dataclass_type)}
+    orm_fields: Set[str] = set(getattr(tortoise_model, "_meta").fields_map.keys())
+
+    diff = dto_fields ^ orm_fields  # symmetric difference
+
+    if exclude:
+        diff -= set(exclude)
+
+    return sorted(diff)
+
+class TestAPIKEY:
+    def test_with_apikey_response_dto(self):
+        symmetric_diff = symmetric_field_diff(APIKeyResponseDTO, APIKEY)
+        assert len(symmetric_diff) == 0
+
+class TestCodeChunks:
+    def test_with_code_chunks_response_dto(self):
+        symmetric_diff = symmetric_field_diff(CodeChunksResponseDTO, CodeChunks)
+        assert len(symmetric_diff) == 0
+
+class TestGitLabel:
+    def test_with_git_label_response_dto(self):
+        symmetric_diff = symmetric_field_diff(GitLabelResponseDTO, GitLabel)
+        assert len(symmetric_diff) == 0
+
+class TestQueueProcessingRegistry:
+    def test_with_queue_processing_registry_response_dto(self):
+        symmetric_diff = symmetric_field_diff(QueueProcessingRegistryResponseDTO, QueueProcessingRegistry)
+        assert len(symmetric_diff) == 0
+
+class TestRepo:
+    def test_with_repo_response_dto(self):
+        symmetric_diff = symmetric_field_diff(RepoResponseDTO, Repo)
+        assert len(symmetric_diff) == 0
+
+class TestUser:
+    def test_with_user_response_dto(self):
+        symmetric_diff = symmetric_field_diff(UserResponseDTO, User)
+        assert len(symmetric_diff) == 0

--- a/test/parity/models_src/models_dto_field_parity.py
+++ b/test/parity/models_src/models_dto_field_parity.py
@@ -1,6 +1,6 @@
 import dataclasses
 from dataclasses import fields, is_dataclass
-from typing import List, Optional, Set, Type
+from typing import Iterable, List, Optional, Set, Type
 
 from tortoise import Model
 
@@ -18,9 +18,9 @@ from models_src.models.repo import Repo
 from models_src.models.user import User
 
 def symmetric_field_diff(
-    dataclass_type: Type[dataclasses],
+    dataclass_type: Type[dataclasses.dataclass],
     tortoise_model: Type[Model],
-    exclude: Optional[set[str]] = None,
+    exclude: Optional[Iterable[str]] = None,
 ) -> List[str]:
     """
     Return a sorted list of field names that exist in exactly one of:


### PR DESCRIPTION
Meta:

- related jira: https://montyholding.atlassian.net/browse/DEV-35


---

feat: added a parity test between models and dto to keep the Models to DTO response consistent

---

fix: added a missing `total_embeddings` that was added to models, but never added to response DTO thus causing one field to be missing

---

refactor: rather than keeping the status scattered all over the place, spanning more than one microservice, will use `StatusTypes` as the central location, making it easy to traverse and make sense of the code